### PR TITLE
Make Hex utils public

### DIFF
--- a/Sources/OpenTelemetry/HexUtils.swift
+++ b/Sources/OpenTelemetry/HexUtils.swift
@@ -15,14 +15,21 @@ extension OTel {
     /// A collection of utilities when working with hex strings.
     public enum Hex {
         /// A lockup table for quick conversion of bytes to hex-bytes.
-        static let lookup = [
+        public static let lookup = [
             UInt8(ascii: "0"), UInt8(ascii: "1"), UInt8(ascii: "2"), UInt8(ascii: "3"),
             UInt8(ascii: "4"), UInt8(ascii: "5"), UInt8(ascii: "6"), UInt8(ascii: "7"),
             UInt8(ascii: "8"), UInt8(ascii: "9"), UInt8(ascii: "a"), UInt8(ascii: "b"),
             UInt8(ascii: "c"), UInt8(ascii: "d"), UInt8(ascii: "e"), UInt8(ascii: "f"),
         ]
 
-        static func convert<T>(
+        /// Convert the given ASCII bytes into bytes stored in the given target.
+        ///
+        /// - Warning: The target must be exactly half the size of the ASCII bytes.
+        ///
+        /// - Parameters:
+        ///   - ascii: The ASCII bytes to convert.
+        ///   - target: The pointer to store the converted bytes into.
+        public static func convert<T>(
             _ ascii: T,
             toBytes target: UnsafeMutableRawBufferPointer
         ) where T: RandomAccessCollection, T.Element == UInt8 {


### PR DESCRIPTION
The Hex utils should be public because they can also benefit library extensions such as [opentelemetry-swift-xray](https://github.com/slashmo/opentelemetry-swift-xray).