### PR TITLE
Make OTel.SpanContext initializer public

### DIFF
--- a/Sources/OpenTelemetry/Propagation/W3CPropagator.swift
+++ b/Sources/OpenTelemetry/Propagation/W3CPropagator.swift
@@ -89,9 +89,7 @@ extension OTel {
                 return OTel.SpanContext(
                     traceID: OTel.TraceID(bytes: traceIDBytes),
                     spanID: OTel.SpanID(bytes: spanIDBytes),
-                    parentSpanID: nil,
                     traceFlags: traceFlags,
-                    traceState: nil,
                     isRemote: true
                 )
             }

--- a/Sources/OpenTelemetry/SpanContext/SpanContext.swift
+++ b/Sources/OpenTelemetry/SpanContext/SpanContext.swift
@@ -34,5 +34,32 @@ extension OTel {
 
         /// Whether this context belongs to a remote span.
         public let isRemote: Bool
+
+        /// Initialize a new span context.
+        ///
+        /// - Parameters:
+        ///   - traceID: The trace ID of the span.
+        ///   - spanID: The ID of the span itself.
+        ///   - parentSpanID: The ID of the optional parent span, defaults to `nil`.
+        ///   - traceFlags: The trace flags of the span.
+        ///   - traceState: The optional trace state, defaults to `nil`.
+        ///   - isRemote: Whether the span is remote.
+        ///
+        /// - Note: Span contexts should only be created by `OTelPropagator`s when extracting from a carrier.
+        public init(
+            traceID: OTel.TraceID,
+            spanID: OTel.SpanID,
+            parentSpanID: OTel.SpanID? = nil,
+            traceFlags: OTel.TraceFlags,
+            traceState: OTel.TraceState? = nil,
+            isRemote: Bool
+        ) {
+            self.traceID = traceID
+            self.spanID = spanID
+            self.parentSpanID = parentSpanID
+            self.traceFlags = traceFlags
+            self.traceState = traceState
+            self.isRemote = isRemote
+        }
     }
 }

--- a/Sources/OpenTelemetry/SpanContext/TraceState.swift
+++ b/Sources/OpenTelemetry/SpanContext/TraceState.swift
@@ -16,11 +16,14 @@ extension OTel {
     ///
     /// - SeeAlso: [W3C TraceContext: TraceState](https://www.w3.org/TR/2020/REC-trace-context-1-20200206/#tracestate-header)
     public struct TraceState {
-        typealias Storage = [(vendor: String, value: String)]
+        public typealias Storage = [(vendor: String, value: String)]
 
         private var storage: Storage
 
-        init(_ storage: Storage) {
+        /// Initialize trace state.
+        ///
+        /// - Parameter storage: The vendor/value pairs stored in the trace state.
+        public init(_ storage: Storage) {
             self.storage = storage
         }
     }

--- a/Tests/OpenTelemetryTests/Exporting/NoOpSpanExporterTests.swift
+++ b/Tests/OpenTelemetryTests/Exporting/NoOpSpanExporterTests.swift
@@ -29,7 +29,6 @@ final class NoOpSpanExporterTests: XCTestCase {
                 spanID: .random(),
                 parentSpanID: .random(),
                 traceFlags: .sampled,
-                traceState: nil,
                 isRemote: false
             ),
             baggage: .topLevel,

--- a/Tests/OpenTelemetryTests/Processing/SimpleSpanProcessorTests.swift
+++ b/Tests/OpenTelemetryTests/Processing/SimpleSpanProcessorTests.swift
@@ -32,7 +32,6 @@ final class SimpleSpanProcessorTests: XCTestCase {
                 spanID: .random(),
                 parentSpanID: .random(),
                 traceFlags: .sampled,
-                traceState: nil,
                 isRemote: false
             ),
             baggage: .topLevel,
@@ -61,7 +60,6 @@ final class SimpleSpanProcessorTests: XCTestCase {
                 spanID: .random(),
                 parentSpanID: .random(),
                 traceFlags: [],
-                traceState: nil,
                 isRemote: false
             ),
             baggage: .topLevel,
@@ -90,7 +88,6 @@ final class SimpleSpanProcessorTests: XCTestCase {
                 spanID: .random(),
                 parentSpanID: .random(),
                 traceFlags: .sampled,
-                traceState: nil,
                 isRemote: false
             ),
             baggage: .topLevel,

--- a/Tests/OpenTelemetryTests/Propagation/W3CPropagatorTests.swift
+++ b/Tests/OpenTelemetryTests/Propagation/W3CPropagatorTests.swift
@@ -27,7 +27,6 @@ final class W3CPropagatorTests: XCTestCase {
             spanID: .stub,
             parentSpanID: .stub,
             traceFlags: [],
-            traceState: nil,
             isRemote: false
         )
         var headers = [String: String]()
@@ -43,7 +42,6 @@ final class W3CPropagatorTests: XCTestCase {
             spanID: .stub,
             parentSpanID: .stub,
             traceFlags: .sampled,
-            traceState: nil,
             isRemote: false
         )
         var headers = [String: String]()

--- a/Tests/OpenTelemetryTests/RecordedSpanTests.swift
+++ b/Tests/OpenTelemetryTests/RecordedSpanTests.swift
@@ -22,7 +22,6 @@ final class RecordedSpanTests: XCTestCase {
             spanID: .random(),
             parentSpanID: .random(),
             traceFlags: .sampled,
-            traceState: nil,
             isRemote: false
         )
         var baggage = Baggage.topLevel
@@ -73,7 +72,6 @@ final class RecordedSpanTests: XCTestCase {
             spanID: .random(),
             parentSpanID: .random(),
             traceFlags: .sampled,
-            traceState: nil,
             isRemote: false
         )
         var baggage = Baggage.topLevel

--- a/Tests/OpenTelemetryTests/Sampling/ParentBasedSamplerTests.swift
+++ b/Tests/OpenTelemetryTests/Sampling/ParentBasedSamplerTests.swift
@@ -39,9 +39,7 @@ final class ParentBasedSamplerTests: XCTestCase {
         let parentSpanContext = OTel.SpanContext(
             traceID: .random(),
             spanID: .random(),
-            parentSpanID: nil,
             traceFlags: .sampled,
-            traceState: nil,
             isRemote: true
         )
 
@@ -64,9 +62,7 @@ final class ParentBasedSamplerTests: XCTestCase {
         let parentSpanContext = OTel.SpanContext(
             traceID: .random(),
             spanID: .random(),
-            parentSpanID: nil,
             traceFlags: [],
-            traceState: nil,
             isRemote: true
         )
 
@@ -89,9 +85,7 @@ final class ParentBasedSamplerTests: XCTestCase {
         let parentSpanContext = OTel.SpanContext(
             traceID: .random(),
             spanID: .random(),
-            parentSpanID: nil,
             traceFlags: .sampled,
-            traceState: nil,
             isRemote: false
         )
 
@@ -114,9 +108,7 @@ final class ParentBasedSamplerTests: XCTestCase {
         let parentSpanContext = OTel.SpanContext(
             traceID: .random(),
             spanID: .random(),
-            parentSpanID: nil,
             traceFlags: [],
-            traceState: nil,
             isRemote: false
         )
 

--- a/Tests/OpenTelemetryTests/TracerTests.swift
+++ b/Tests/OpenTelemetryTests/TracerTests.swift
@@ -103,9 +103,7 @@ final class TracerTests: XCTestCase {
         let parentSpanContext = OTel.SpanContext(
             traceID: .random(),
             spanID: .random(),
-            parentSpanID: nil,
             traceFlags: [],
-            traceState: nil,
             isRemote: true
         )
         var baggage = Baggage.topLevel
@@ -160,7 +158,6 @@ final class TracerTests: XCTestCase {
             OTel.SpanContext(
                 traceID: .stub,
                 spanID: .stub,
-                parentSpanID: nil,
                 traceFlags: .sampled,
                 traceState: OTel.TraceState([(vendor: "key", value: "value")]),
                 isRemote: true

--- a/Tests/OtlpGRPCSpanExportingTests/TypeConversionTests.swift
+++ b/Tests/OtlpGRPCSpanExportingTests/TypeConversionTests.swift
@@ -31,9 +31,7 @@ final class TypeConversionTests: XCTestCase {
             context: OTel.SpanContext(
                 traceID: .init(bytes: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)),
                 spanID: .init(bytes: (1, 2, 3, 4, 5, 6, 7, 8)),
-                parentSpanID: nil,
                 traceFlags: .sampled,
-                traceState: nil,
                 isRemote: false
             ),
             baggage: .topLevel,
@@ -328,7 +326,6 @@ final class TypeConversionTests: XCTestCase {
         baggage.spanContext = OTel.SpanContext(
             traceID: OTel.TraceID(bytes: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)),
             spanID: OTel.SpanID(bytes: (1, 2, 3, 4, 5, 6, 7, 8)),
-            parentSpanID: nil,
             traceFlags: .sampled,
             traceState: OTel.TraceState([(vendor: "test", value: "test")]),
             isRemote: false


### PR DESCRIPTION
`OTelPropagator`s in external repositories need to be able to initialize span contexts.