### PR TITLE
Conform OTel.SpanContext to CustomStringConvertible

### DIFF
--- a/Sources/OpenTelemetry/SpanContext/Baggage+SpanContext.swift
+++ b/Sources/OpenTelemetry/SpanContext/Baggage+SpanContext.swift
@@ -24,6 +24,15 @@ extension Baggage {
     }
 }
 
+extension OTel.SpanContext: CustomStringConvertible {
+    public var description: String {
+        let flagString = traceFlags.rawValue < 10 ? "0\(traceFlags.rawValue)" : "\(traceFlags.rawValue)"
+        return "\(traceID)-\(spanID)-\(flagString)"
+    }
+}
+
 private enum SpanContextKey: BaggageKey {
     typealias Value = OTel.SpanContext
+
+    static var nameOverride: String? = "otel-span-context"
 }

--- a/Tests/OpenTelemetryTests/SpanContext/SpanContextTests.swift
+++ b/Tests/OpenTelemetryTests/SpanContext/SpanContextTests.swift
@@ -35,4 +35,16 @@ final class SpanContextTests: XCTestCase {
         baggage.spanContext = nil
         XCTAssertNil(baggage.spanContext)
     }
+
+    func test_stringConvertible_notSampled() {
+        let spanContext = OTel.SpanContext.stub()
+
+        XCTAssertEqual(spanContext.description, "\(OTel.TraceID.stub)-\(OTel.SpanID.stub)-00")
+    }
+
+    func test_stringConvertible_sampled() {
+        let spanContext = OTel.SpanContext.stub(traceFlags: .sampled)
+
+        XCTAssertEqual(spanContext.description, "\(OTel.TraceID.stub)-\(OTel.SpanID.stub)-01")
+    }
 }


### PR DESCRIPTION
Closes #6 

Instead of the planned `trace-id` `nameOverride` I went with `otel-span-context` because the value represents more than just the `traceID`. The `otel-` prefix ensures the name doesn't clash with Baggage items produced by other `Instrument`s.