### PR TITLE
Shut down processor when shutting down OTel

### DIFF
--- a/Sources/OpenTelemetry/OTel.swift
+++ b/Sources/OpenTelemetry/OTel.swift
@@ -106,6 +106,6 @@ public final class OTel {
     ///
     /// - Returns: A future that completes once `OTel` and its sub-components was shutdown.
     public func shutdown() -> EventLoopFuture<Void> {
-        eventLoopGroup.next().makeSucceededVoidFuture()
+        processor.shutdownGracefully()
     }
 }


### PR DESCRIPTION
When shutting down `OTel` we should also make sure to shut down the processor which in turns shuts down the exporter.