### PR TITLE
Run process detector before environment detector

### DIFF
--- a/Sources/OpenTelemetry/Resource/ResourceDetection.swift
+++ b/Sources/OpenTelemetry/Resource/ResourceDetection.swift
@@ -43,8 +43,8 @@ extension OTel.ResourceDetection {
         switch self {
         case .automatic(let additionalDetectors):
             let detectors = [
-                OTel.EnvironmentResourceDetector(eventLoopGroup: eventLoopGroup),
                 OTel.ProcessResourceDetector(eventLoopGroup: eventLoopGroup),
+                OTel.EnvironmentResourceDetector(eventLoopGroup: eventLoopGroup),
             ] + additionalDetectors
 
             promise.completeWith(.reduce(


### PR DESCRIPTION
This change allows users to override attributes detected through the `ProcessResourceDetector` via the `EnvironmentResourceDetector`.