### PR TITLE
Ignore empty batches in BatchSpanProcessor

### DIFF
--- a/Sources/OpenTelemetry/Processing/BatchSpanProcessor.swift
+++ b/Sources/OpenTelemetry/Processing/BatchSpanProcessor.swift
@@ -71,6 +71,9 @@ extension OTel {
 
         private func exportBatch(_ task: RepeatedTask) -> EventLoopFuture<Void> {
             queueLock.withLock {
+                guard !queue.isEmpty else {
+                    return eventLoopGroup.next().makeSucceededVoidFuture()
+                }
                 let spans = queue.prefix(maxBatchSize)
                 queue.removeFirst(spans.count)
                 return exporter.export(spans)

--- a/Tests/OpenTelemetryTests/Helpers/InMemorySpanExporter.swift
+++ b/Tests/OpenTelemetryTests/Helpers/InMemorySpanExporter.swift
@@ -19,6 +19,7 @@ final class InMemorySpanExporter: OTelSpanExporter {
     private let eventLoopGroup: EventLoopGroup
     private let lock = Lock()
     private var _spans = [OTel.RecordedSpan]()
+    private(set) var numberOfExports = 0
 
     var spans: [OTel.RecordedSpan] {
         lock.withLock { _spans }
@@ -29,6 +30,7 @@ final class InMemorySpanExporter: OTelSpanExporter {
     }
 
     func export<C: Collection>(_ batch: C) -> EventLoopFuture<Void> where C.Element == OTel.RecordedSpan {
+        numberOfExports += 1
         lock.withLockVoid {
             _spans.append(contentsOf: batch)
         }


### PR DESCRIPTION
`BatchSpanProcessor` now ignores empty batches, because there's no reason for the exporter to be invoked with an empty batch.