### PR TITLE
Add support for task-local Baggage API

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ jobs:
         images:
         - swift:5.3
         - swift:5.4
+        - swift:5.5
         - swiftlang/swift:nightly-master
     container: ${{ matrix.images }}
     steps:
@@ -35,6 +36,7 @@ jobs:
         images:
         - swift:5.3
         - swift:5.4
+        - swift:5.5
         - swiftlang/swift:nightly-master
     container: ${{ matrix.images }}
     defaults:

--- a/Examples/Onboarding/Sources/Onboarding/main.swift
+++ b/Examples/Onboarding/Sources/Onboarding/main.swift
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Logging
 import NIO
 import OpenTelemetry
 import OtlpGRPCSpanExporting
@@ -19,6 +20,12 @@ import Tracing
 // In a real application, you should re-use your existing
 // event loop group instead of creating a new one.
 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+
+LoggingSystem.bootstrap { label in
+    var handler = StreamLogHandler.standardOutput(label: label)
+    handler.logLevel = .trace
+    return handler
+}
 
 // MARK: - Configure OTel
 

--- a/Examples/Onboarding/docker/collector-config.yaml
+++ b/Examples/Onboarding/docker/collector-config.yaml
@@ -10,7 +10,8 @@ exporters:
 
   jaeger:
     endpoint: "jaeger:14250"
-    insecure: true
+    tls:
+      insecure: true
 
   zipkin:
     endpoint: "http://zipkin:9411/api/v2/spans"

--- a/Examples/Onboarding/docker/docker-compose.yaml
+++ b/Examples/Onboarding/docker/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   otel-collector:
-    image: otel/opentelemetry-collector:latest
+    image: otel/opentelemetry-collector-contrib:latest
     command: ["--config=/etc/config.yaml"]
     volumes:
       - ./collector-config.yaml:/etc/config.yaml

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,6 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-distributed-tracing.git", .upToNextMinor(from: "0.2.0")),
-//        .package(url: "https://github.com/apple/swift-distributed-tracing-baggage.git", .upToNextMinor(from: "0.2.0")),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.0.0"),
@@ -18,13 +17,11 @@ let package = Package(
         .target(name: "OpenTelemetry", dependencies: [
             .product(name: "Logging", package: "swift-log"),
             .product(name: "Tracing", package: "swift-distributed-tracing"),
-//            .product(name: "InstrumentationBaggage", package: "swift-distributed-tracing-baggage"),
             .product(name: "NIO", package: "swift-nio"),
         ]),
         .testTarget(name: "OpenTelemetryTests", dependencies: [
             .target(name: "OpenTelemetry"),
             .product(name: "Tracing", package: "swift-distributed-tracing"),
-//            .product(name: "InstrumentationBaggage", package: "swift-distributed-tracing-baggage"),
         ]),
 
         .target(name: "OtlpGRPCSpanExporting", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -8,25 +8,28 @@ let package = Package(
         .library(name: "OtlpGRPCSpanExporting", targets: ["OtlpGRPCSpanExporting"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-distributed-tracing.git", .upToNextMinor(from: "0.1.2")),
-        .package(url: "https://github.com/apple/swift-distributed-tracing-baggage.git", .upToNextMinor(from: "0.1.0")),
+        .package(url: "https://github.com/apple/swift-distributed-tracing.git", .upToNextMinor(from: "0.2.0")),
+//        .package(url: "https://github.com/apple/swift-distributed-tracing-baggage.git", .upToNextMinor(from: "0.2.0")),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.0.0"),
     ],
     targets: [
         .target(name: "OpenTelemetry", dependencies: [
+            .product(name: "Logging", package: "swift-log"),
             .product(name: "Tracing", package: "swift-distributed-tracing"),
-            .product(name: "Baggage", package: "swift-distributed-tracing-baggage"),
+//            .product(name: "InstrumentationBaggage", package: "swift-distributed-tracing-baggage"),
             .product(name: "NIO", package: "swift-nio"),
         ]),
         .testTarget(name: "OpenTelemetryTests", dependencies: [
             .target(name: "OpenTelemetry"),
             .product(name: "Tracing", package: "swift-distributed-tracing"),
-            .product(name: "Baggage", package: "swift-distributed-tracing-baggage"),
+//            .product(name: "InstrumentationBaggage", package: "swift-distributed-tracing-baggage"),
         ]),
 
         .target(name: "OtlpGRPCSpanExporting", dependencies: [
             .target(name: "OpenTelemetry"),
+            .product(name: "Logging", package: "swift-log"),
             .product(name: "NIO", package: "swift-nio"),
             .product(name: "GRPC", package: "grpc-swift"),
         ]),

--- a/Sources/OpenTelemetry/SpanContext/Baggage+SpanContext.swift
+++ b/Sources/OpenTelemetry/SpanContext/Baggage+SpanContext.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import CoreBaggage
+import InstrumentationBaggage
 
 extension Baggage {
     public internal(set) var spanContext: OTel.SpanContext? {

--- a/Sources/OpenTelemetry/SpanContext/SpanContext.swift
+++ b/Sources/OpenTelemetry/SpanContext/SpanContext.swift
@@ -63,3 +63,7 @@ extension OTel {
         }
     }
 }
+
+#if swift(>=5.5) && canImport(_Concurrency)
+extension OTel.SpanContext: Sendable {}
+#endif

--- a/Sources/OpenTelemetry/SpanContext/SpanID.swift
+++ b/Sources/OpenTelemetry/SpanContext/SpanID.swift
@@ -90,3 +90,7 @@ extension OTel.SpanID: Hashable {
         hasher.combine(_bytes.7)
     }
 }
+
+#if swift(>=5.5) && canImport(_Concurrency)
+extension OTel.SpanID: Sendable {}
+#endif

--- a/Sources/OpenTelemetry/SpanContext/TraceFlags.swift
+++ b/Sources/OpenTelemetry/SpanContext/TraceFlags.swift
@@ -32,3 +32,7 @@ extension OTel {
         public static let sampled = TraceFlags(rawValue: 1 << 0)
     }
 }
+
+#if swift(>=5.5) && canImport(_Concurrency)
+extension OTel.TraceFlags: Sendable {}
+#endif

--- a/Sources/OpenTelemetry/SpanContext/TraceID.swift
+++ b/Sources/OpenTelemetry/SpanContext/TraceID.swift
@@ -125,3 +125,7 @@ extension OTel.TraceID: Hashable {
         hasher.combine(_bytes.15)
     }
 }
+
+#if swift(>=5.5) && canImport(_Concurrency)
+extension OTel.TraceID: Sendable {}
+#endif

--- a/Sources/OpenTelemetry/SpanContext/TraceState.swift
+++ b/Sources/OpenTelemetry/SpanContext/TraceState.swift
@@ -44,3 +44,7 @@ extension OTel.TraceState: CustomStringConvertible {
         storage.map { "\($0)=\($1)" }.joined(separator: ",")
     }
 }
+
+#if swift(>=5.5) && canImport(_Concurrency)
+extension OTel.TraceState: Sendable {}
+#endif

--- a/Sources/OpenTelemetry/Tracer.swift
+++ b/Sources/OpenTelemetry/Tracer.swift
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 import struct Dispatch.DispatchWallTime
+import Logging
 import NIOConcurrencyHelpers
 import Tracing
 

--- a/Tests/OpenTelemetryTests/Helpers/Span+Stub.swift
+++ b/Tests/OpenTelemetryTests/Helpers/Span+Stub.swift
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 import struct Dispatch.DispatchWallTime
+import Logging
 @testable import OpenTelemetry
 import Tracing
 

--- a/Tests/OpenTelemetryTests/RecordedSpanTests.swift
+++ b/Tests/OpenTelemetryTests/RecordedSpanTests.swift
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Logging
 @testable import OpenTelemetry
 import Tracing
 import XCTest
@@ -88,13 +89,6 @@ final class RecordedSpanTests: XCTestCase {
         let span = OTel.Tracer.Span.stub(spanContext: nil)
 
         XCTAssertNil(OTel.RecordedSpan(span), "Spans without context should not be convertible to a RecordedSpan.")
-    }
-}
-
-extension SpanStatus: Equatable {
-    public static func == (lhs: SpanStatus, rhs: SpanStatus) -> Bool {
-        lhs.code == rhs.code
-            && lhs.message == rhs.message
     }
 }
 

--- a/Tests/OpenTelemetryTests/SpanContext/SpanContextTests.swift
+++ b/Tests/OpenTelemetryTests/SpanContext/SpanContextTests.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import CoreBaggage
+import InstrumentationBaggage
 @testable import OpenTelemetry
 import XCTest
 

--- a/Tests/OpenTelemetryTests/TracerTests.swift
+++ b/Tests/OpenTelemetryTests/TracerTests.swift
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Logging
 import NIO
 @testable import OpenTelemetry
 import Tracing

--- a/scripts/validate_license_headers.sh
+++ b/scripts/validate_license_headers.sh
@@ -31,7 +31,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
   # this needs to replace all acceptable forms with 'YEARS'
-  sed -e 's/2020-2021/YEARS/' -e 's/2020/YEARS/' -e 's/2021/YEARS/'
+  sed -e 's/2020-2022/YEARS/' -e 's/2020/YEARS/' -e 's/2021/YEARS/' -e 's/2022/YEARS/'
 }
 
 printf "=> Checking license headers\n"


### PR DESCRIPTION
## Breaking changes

- Now depends on Tracing `0.2.0 ..< 0.3.0`, which replaced manual `LoggingContext`-based propagation with automatic propagation via task-locals. ([Distributed Tracing 0.2.0](https://github.com/apple/swift-distributed-tracing/releases/tag/0.2.0))

## Changes

- `OTel.SpanContext` and related structs now conform to `Sendable`.
- CI now runs for 5.5 as well