### PR TITLE
Fixed build failing for iOS and iPad

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,10 +9,11 @@ jobs:
       fail-fast: false
       matrix:
         images:
-        - swift:5.3
-        - swift:5.4
-        - swift:5.5
-        - swiftlang/swift:nightly-master
+          - swift:5.3
+          - swift:5.4
+          - swift:5.5
+          - swift:5.6
+          - swiftlang/swift:nightly-master
     container: ${{ matrix.images }}
     steps:
       - name: Checkout
@@ -21,7 +22,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .build
-          key: ${{ runner.os }}-${{ matrix.images }}-spm-${{ hashFiles('**/Package.resolved') }}-v2
+          key: ${{ runner.os }}-${{ matrix.images }}-spm-${{ hashFiles('Package.swift') }}
           restore-keys: ${{ runner.os }}-${{ matrix.images }}-spm-
       - name: Resolve Swift dependencies
         run: swift package resolve
@@ -30,28 +31,17 @@ jobs:
 
   compile-onboarding-example:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        images:
-        - swift:5.3
-        - swift:5.4
-        - swift:5.5
-        - swiftlang/swift:nightly-master
-    container: ${{ matrix.images }}
     defaults:
       run:
         working-directory: ./Examples/Onboarding
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Cache Swift PM
-        uses: actions/cache@v2
+      - name: Install Swift
+        uses: slashmo/install-swift@v0.1.0
         with:
-          path: ./Examples/Onboarding/.build
-          key: ${{ runner.os }}-${{ matrix.images }}-spm-${{ hashFiles('**/Examples/Onboarding/Package.resolved') }}
-          restore-keys: ${{ runner.os }}-${{ matrix.images }}-spm-
+          version: 5.6
       - name: Resolve Swift dependencies
         run: swift package resolve
       - name: Build
-        run: swift build --enable-test-discovery
+        run: swift build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Swift
-        uses: slashmo/install-swift@v0.1.0
+        uses: slashmo/install-swift@v0.3.0
         with:
           version: 5.6
       - name: Resolve Swift dependencies

--- a/Examples/Onboarding/Package.resolved
+++ b/Examples/Onboarding/Package.resolved
@@ -6,17 +6,8 @@
         "repositoryURL": "https://github.com/grpc/grpc-swift.git",
         "state": {
           "branch": null,
-          "revision": "9e464a75079928366aa7041769a271fac89271bf",
-          "version": "1.0.0"
-        }
-      },
-      {
-        "package": "opentelemetry-swift",
-        "repositoryURL": "https://github.com/slashmo/opentelemetry-swift.git",
-        "state": {
-          "branch": "main",
-          "revision": "0b6cbb2fbddefdc0e2e604119d015efe316c1a14",
-          "version": null
+          "revision": "d772b688d718c2eb29f99b535fc4d92ebba031c5",
+          "version": "1.8.1"
         }
       },
       {
@@ -24,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-distributed-tracing.git",
         "state": {
           "branch": null,
-          "revision": "fce1f7c91ad5a733500ea1cdd7ccd7aed9130536",
-          "version": "0.1.4"
+          "revision": "7a89c904d80fd2dc7c6071806f38d5d0b2d5a1b5",
+          "version": "0.2.0"
         }
       },
       {
@@ -33,17 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-distributed-tracing-baggage.git",
         "state": {
           "branch": null,
-          "revision": "b68b3277985555995298426a35084b832dbc51ae",
-          "version": "0.1.1"
-        }
-      },
-      {
-        "package": "swift-distributed-tracing-baggage-core",
-        "repositoryURL": "https://github.com/apple/swift-distributed-tracing-baggage-core.git",
-        "state": {
-          "branch": null,
-          "revision": "9a2884a37f39e08ebd225627c400feae9c6ea8df",
-          "version": "0.1.1"
+          "revision": "c8457ce61adc6a3b9e6223ca147f5196f99e22cc",
+          "version": "0.2.3"
         }
       },
       {
@@ -60,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "3be4e0980075de10a4bc8dee07491d49175cfd7a",
-          "version": "2.27.0"
+          "revision": "124119f0bb12384cef35aa041d7c3a686108722d",
+          "version": "2.40.0"
         }
       },
       {
@@ -69,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "de1c80ad1fdff1ba772bcef6b392c3ef735f39a6",
-          "version": "1.8.0"
+          "revision": "a75e92bde3683241c15df3dd905b7a6dcac4d551",
+          "version": "1.12.1"
         }
       },
       {
@@ -78,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "f4736a3b78a2bbe3feb7fc0f33f6683a8c27974c",
-          "version": "1.16.3"
+          "revision": "108ac15087ea9b79abb6f6742699cf31de0e8772",
+          "version": "1.22.0"
         }
       },
       {
@@ -87,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "07c160b8724ee53a4b776328122be6338ff12bf2",
-          "version": "2.11.0"
+          "revision": "42436a25ff32c390465567f5c089a9a8ce8d7baf",
+          "version": "2.20.0"
         }
       },
       {
@@ -96,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "1d28d48e071727f4558a8a4bb1894472abc47a58",
-          "version": "1.9.2"
+          "revision": "2cb54f91ddafc90832c5fa247faf5798d0a7c204",
+          "version": "1.13.0"
         }
       },
       {
@@ -105,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
-          "revision": "e1904bf5a5f79cb7e0ff68a427a53a93b652fcd1",
-          "version": "1.15.0"
+          "revision": "e1499bc69b9040b29184f7f2996f7bab467c1639",
+          "version": "1.19.0"
         }
       }
     ]

--- a/Examples/Onboarding/Package.swift
+++ b/Examples/Onboarding/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .executable(name: "onboarding", targets: ["Onboarding"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/slashmo/opentelemetry-swift.git", .branch("main")),
+        .package(path: "../.."),
     ],
     targets: [
         .target(name: "Onboarding", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "OtlpGRPCSpanExporting", targets: ["OtlpGRPCSpanExporting"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-distributed-tracing.git", .upToNextMinor(from: "0.2.0")),
+        .package(url: "https://github.com/apple/swift-distributed-tracing.git", .upToNextMinor(from: "0.3.0")),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.0.0"),

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ a trace created by "onboarding":
 To add "OpenTelemetry Swift" to our project, we first need to include it as a package dependency:
 
 ```swift
-.package(url: "https://github.com/slashmo/opentelemetry-swift.git", from: "0.1.0"),
+.package(url: "https://github.com/slashmo/opentelemetry-swift.git", from: "0.3.0"),
 ```
 
 Then we add `OpenTelemetry` to our executable target:
@@ -63,7 +63,7 @@ try group.syncShutdownGracefully()
 ```
 
 > ⚠️ With this setup, ended spans will be ignored and not exported to a tracing backend. Read on to learn more
-about [how to configure processing & exporting](#configuring-processing-and-exporting).
+> about [how to configure processing & exporting](#configuring-processing-and-exporting).
 
 ### Configuring processing and exporting
 
@@ -380,7 +380,7 @@ OTel.ResourceDetection.none
 
 To ensure a consistent code style we use [SwiftFormat](https://github.com/nicklockwood/SwiftFormat).
 To automatically run it before you push to GitHub, you may define a `pre-push` Git hook executing
-the *soundness* script:
+the _soundness_ script:
 
 ```sh
 echo './scripts/soundness.sh' > .git/hooks/pre-push

--- a/Sources/OpenTelemetry/OTel.swift
+++ b/Sources/OpenTelemetry/OTel.swift
@@ -18,7 +18,7 @@ import Tracing
 /// The main entry point to using OpenTelemetry.
 public final class OTel {
     /// The current `semver` version of the library.
-    public static let versionString = "0.1.0"
+    public static let versionString = "0.3.0"
 
     private let eventLoopGroup: EventLoopGroup
     private let resourceDetection: ResourceDetection

--- a/Sources/OpenTelemetry/Resource/ProcessResourceDetector.swift
+++ b/Sources/OpenTelemetry/Resource/ProcessResourceDetector.swift
@@ -34,8 +34,6 @@ extension OTel {
             if #available(macOS 10.12, *) {
                 attributes["process.owner"] = ProcessInfo.processInfo.userName
             }
-            #else
-            attributes["process.owner"] = ProcessInfo.processInfo.userName
             #endif
 
             return eventLoopGroup.next().makeSucceededFuture(Resource(attributes: attributes))

--- a/Sources/OpenTelemetry/Resource/ProcessResourceDetector.swift
+++ b/Sources/OpenTelemetry/Resource/ProcessResourceDetector.swift
@@ -34,6 +34,8 @@ extension OTel {
             if #available(macOS 10.12, *) {
                 attributes["process.owner"] = ProcessInfo.processInfo.userName
             }
+            #elseif os(Linux)
+            attributes["process.owner"] = ProcessInfo.processInfo.userName
             #endif
 
             return eventLoopGroup.next().makeSucceededFuture(Resource(attributes: attributes))

--- a/Tests/OpenTelemetryTests/Resource/ProcessResourceDetectorTests.swift
+++ b/Tests/OpenTelemetryTests/Resource/ProcessResourceDetectorTests.swift
@@ -24,14 +24,16 @@ final class ProcessResourceDetectorTests: XCTestCase {
         XCTAssertNotNil(resource.attributes["process.pid"])
         XCTAssertNotNil(resource.attributes["process.executable.name"])
         XCTAssertNotNil(resource.attributes["process.executable.path"])
+        #if os(macOS) || os(Linux)
         XCTAssertNotNil(resource.attributes["process.command"])
+        #endif
         XCTAssertNotNil(resource.attributes["process.command_line"])
 
         #if os(macOS)
         if #available(macOS 10.12, *) {
             XCTAssertNotNil(resource.attributes["process.owner"])
         }
-        #else
+        #elseif os(Linux)
         XCTAssertNotNil(resource.attributes["process.owner"])
         #endif
     }

--- a/Tests/OpenTelemetryTests/Resource/ResourceDetectionTests.swift
+++ b/Tests/OpenTelemetryTests/Resource/ResourceDetectionTests.swift
@@ -30,7 +30,9 @@ final class ResourceDetectionTests: XCTestCase {
 
         XCTAssertNotNil(resource.attributes["process.executable.name"])
         XCTAssertNotNil(resource.attributes["process.executable.path"])
+        #if os(macOS) || os(Linux)
         XCTAssertNotNil(resource.attributes["process.command"])
+        #endif
         XCTAssertNotNil(resource.attributes["process.command_line"])
         XCTAssertEqual(resource.attributes["process.pid"]?.toSpanAttribute(), 42)
         XCTAssertEqual(resource.attributes["custom"]?.toSpanAttribute(), "value")


### PR DESCRIPTION
The build was failing for iOS and iPad, due to the package wanting to access the processinfo.username property. This property keeps track of which user is currently logged in on MacOS and thus is unavailable on iOS and iPad, where we only have a single user.

This short PR fixes the problem.

[Link](https://developer.apple.com/documentation/foundation/processinfo) to Apple documentation for reference.